### PR TITLE
Improve UI/UX by aligning checkboxes to the left of the labels.

### DIFF
--- a/app/assets/stylesheets/admin/spree_clean.css
+++ b/app/assets/stylesheets/admin/spree_clean.css
@@ -1,3 +1,8 @@
 /*
  *= require admin/spree_core
 */
+
+.resources-list input {
+  margin-bottom: 5px !important;
+}
+

--- a/app/views/spree/admin/clean_data/show.html.erb
+++ b/app/views/spree/admin/clean_data/show.html.erb
@@ -16,86 +16,86 @@
 
 <%= form_tag admin_destroy_data_path, :method => :delete do %>
   <p data-hook="resources-list" class="resources-list">
-    <%= label_tag 'resources[address]', t(:addresses) %>
     <%= check_box_tag 'resources[address]', '1', true %>
+    <%= label_tag 'resources[address]', t(:addresses) %>
     <br />
-    <%= label_tag 'resources[adjustment]', t(:adjustments) %>
     <%= check_box_tag 'resources[adjustment]', '1', true %>
+    <%= label_tag 'resources[adjustment]', t(:adjustments) %>
     <br />
-    <%= label_tag 'resources[asset]', t(:assets) %>
     <%= check_box_tag 'resources[asset]', '1', true %>
+    <%= label_tag 'resources[asset]', t(:assets) %>
     <br />
-    <%= label_tag 'resources[calculator]', t(:calculators) %>
     <%= check_box_tag 'resources[calculator]', '1', true %>
+    <%= label_tag 'resources[calculator]', t(:calculators) %>
     <br />
-    <%= label_tag 'resources[country]', t(:countries) %>
     <%= check_box_tag 'resources[country]', '1', false %>
+    <%= label_tag 'resources[country]', t(:countries) %>
     <br />
-    <%= label_tag 'resources[line_item]', t(:line_items) %>
     <%= check_box_tag 'resources[line_item]', '1', true %>
+    <%= label_tag 'resources[line_item]', t(:line_items) %>
     <br />
-    <%= label_tag 'resources[option_type]', t(:option_types) %>
     <%= check_box_tag 'resources[option_type]', '1', true %>
+    <%= label_tag 'resources[option_type]', t(:option_types) %>
     <br />
-    <%= label_tag 'resources[option_value]', t(:option_values) %>
     <%= check_box_tag 'resources[option_value]', '1', true %>
+    <%= label_tag 'resources[option_value]', t(:option_values) %>
     <br />
-    <%= label_tag 'resources[order]', t(:orders) %>
     <%= check_box_tag 'resources[order]', '1', true %>
+    <%= label_tag 'resources[order]', t(:orders) %>
     <br />
-    <%= label_tag 'resources[payment_method]', t(:payment_methods) %>
     <%= check_box_tag 'resources[payment_method]', '1', true %>
+    <%= label_tag 'resources[payment_method]', t(:payment_methods) %>
     <br />
-    <%= label_tag 'resources[product_option_type]', t(:product_option_types) %>
     <%= check_box_tag 'resources[product_option_type]', '1', true %>
+    <%= label_tag 'resources[product_option_type]', t(:product_option_types) %>
     <br />
-    <%= label_tag 'resources[product_property]', t(:product_properties) %>
     <%= check_box_tag 'resources[product_property]', '1', true %>
+    <%= label_tag 'resources[product_property]', t(:product_properties) %>
     <br />
-    <%= label_tag 'resources[product]', t(:products) %>
     <%= check_box_tag 'resources[product]', '1', true %>
+    <%= label_tag 'resources[product]', t(:products) %>
     <br />
-    <%= label_tag 'resources[property]', t(:properties) %>
     <%= check_box_tag 'resources[property]', '1', true %>
+    <%= label_tag 'resources[property]', t(:properties) %>
     <br />
-    <%= label_tag 'resources[prototype]', t(:prototypes) %>
     <%= check_box_tag 'resources[prototype]', '1', true %>
+    <%= label_tag 'resources[prototype]', t(:prototypes) %>
     <br />
-    <%= label_tag 'resources[shipment]', t(:shipments) %>
     <%= check_box_tag 'resources[shipment]', '1', true %>
+    <%= label_tag 'resources[shipment]', t(:shipments) %>
     <br />
-    <%= label_tag 'resources[shipping_category]', t(:shipping_categories) %>
     <%= check_box_tag 'resources[shipping_category]', '1', true %>
+    <%= label_tag 'resources[shipping_category]', t(:shipping_categories) %>
     <br />
-    <%= label_tag 'resources[shipping_method]', t(:shipping_methods) %>
     <%= check_box_tag 'resources[shipping_method]', '1', true %>
+    <%= label_tag 'resources[shipping_method]', t(:shipping_methods) %>
     <br />
-    <%= label_tag 'resources[state]', t(:states) %>
     <%= check_box_tag 'resources[state]', '1', false %>
+    <%= label_tag 'resources[state]', t(:states) %>
     <br />
-    <%= label_tag 'resources[tax_category]', t(:tax_categories) %>
     <%= check_box_tag 'resources[tax_category]', '1', true %>
+    <%= label_tag 'resources[tax_category]', t(:tax_categories) %>
     <br />
-    <%= label_tag 'resources[tax_rate]', t(:tax_rates) %>
     <%= check_box_tag 'resources[tax_rate]', '1', true %>
+    <%= label_tag 'resources[tax_rate]', t(:tax_rates) %>
     <br />
-    <%= label_tag 'resources[taxonomy]', t(:taxonomies) %>
     <%= check_box_tag 'resources[taxonomy]', '1', true %>
+    <%= label_tag 'resources[taxonomy]', t(:taxonomies) %>
     <br />
-    <%= label_tag 'resources[taxon]', t(:taxons) %>
     <%= check_box_tag 'resources[taxon]', '1', true %>
+    <%= label_tag 'resources[taxon]', t(:taxons) %>
     <br />
-    <%= label_tag 'resources[user]', t(:users) %>
     <%= check_box_tag 'resources[user]', '1', true %>
+    <%= label_tag 'resources[user]', t(:users) %>
     <br />
-    <%= label_tag 'resources[variant]', t(:variants) %>
     <%= check_box_tag 'resources[variant]', '1', true %>
+    <%= label_tag 'resources[variant]', t(:variants) %>
     <br />
-    <%= label_tag 'resources[zone_member]', t(:zone_members) %>
     <%= check_box_tag 'resources[zone_member]', '1', false %>
+    <%= label_tag 'resources[zone_member]', t(:zone_members) %>
     <br />
-    <%= label_tag 'resources[zone]', t(:zones) %>
     <%= check_box_tag 'resources[zone]', '1', false %>
+    <%= label_tag 'resources[zone]', t(:zones) %>
   </p>
 
   <p class="form-buttons" data-hook="buttons">
@@ -103,4 +103,3 @@
     <%= t(:or) %> <%= link_to t(:cancel), edit_admin_general_settings_path %>
   </p>
 <% end %>
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,6 @@
 en:
   clean_data_description: "Bulk delete data from your application."
   clean_data_warning: "Warning: Any actions taken on this page will permanently delete data from the application. Use with caution!"
-  confirm_delete_data: "Are you sure you wish to continure? This operation cannot be undone."
+  confirm_delete_data: "Are you sure you wish to continue? This operation cannot be undone."
   destroy_data: "Destroy Data"
   product_scopes_label: "Product Scopes"


### PR DESCRIPTION
This is a simple UI / UX improvement that aligns checkboxes to the left of the labels which makes it easier to follow, as well as increasing the margin between them by 5px for better viewability.

The resulting change will look like this:
![spree_clean_cssview](https://f.cloud.github.com/assets/455925/49134/ab0a74a6-5942-11e2-9df0-1907d038da99.png)
